### PR TITLE
Update contribution guidelines link to the docs site too

### DIFF
--- a/resources/views/features/open-source.blade.php
+++ b/resources/views/features/open-source.blade.php
@@ -64,7 +64,7 @@
                                     chevron_right
                                 </span>
                             </a>
-                            <a href="https://github.com/SubnauticaNitrox/Nitrox/blob/master/CONTRIBUTING.md" target="_blank">{{ __('os.dev_resources_contribute') }}
+                            <a href="https://subnauticanitrox.github.io/Documentation/" target="_blank">{{ __('os.dev_resources_contribute') }}
                                 <span class="material-icons" style="position: absolute;font-size: 20px;margin: 2px 0px 0px -2px;">
                                     chevron_right
                                 </span>


### PR DESCRIPTION
Hey there! One more for the docs link as PR'd previously here: https://github.com/SubnauticaNitrox/NitroxWebsite/pull/42

The contribution guidelines are now over at the docs too, so just pointing this link there too.

Thanks!